### PR TITLE
Integrate peephole optimization into mc-gcc via shared library

### DIFF
--- a/tests/duff.c
+++ b/tests/duff.c
@@ -2,17 +2,17 @@ void copy(char *to, char *from, int count)
 {
     int n = (count + 7) >> 3;
     switch (count & 7) {
-        case 0:
-              do {
-                *to++ = *from++;
-        case 7: *to++ = *from++;
-        case 6: *to++ = *from++;
-        case 5: *to++ = *from++;
-        case 4: *to++ = *from++;
-        case 3: *to++ = *from++;
-        case 2: *to++ = *from++;
-        case 1: *to++ = *from++;
-              } while (--n > 0);
+    case 0:
+          do {
+            *to++ = *from++;
+    case 7: *to++ = *from++;
+    case 6: *to++ = *from++;
+    case 5: *to++ = *from++;
+    case 4: *to++ = *from++;
+    case 3: *to++ = *from++;
+    case 2: *to++ = *from++;
+    case 1: *to++ = *from++;
+          } while (--n > 0);
     }
 }
 


### PR DESCRIPTION
You no longer need to run the optimization as a standalone app.

$ make mc-so
$ time ./mc-so tests/sieve.c
$ time ./mc-so -Op tests/sieve.c
$ ./mc-so -Op -o sieve tests/sieve.c
$ time ./sieve

With literally a few more lines of changes, a boot-strapped version
of the compiler can also run the shared object optimizer.  I
didn't add that capability, because I don't like that the shared
object  file is not in a 'well known' library directory, and can
be easily deleted independently from the compiler.