### PR TITLE
Add decent performance opt while reducing generated code by ~1%.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ sys	0m0.022s
 $ ./mc-so -DSQUINT_SO -Op -o sieve tests/sieve.c
 $ time ./sieve
 
-real	0m1.190s
-user	0m1.168s
-sys	0m0.022s
+real  0m0.998s
+user  0m0.978s
+sys   0m0.020s
 
 $ gcc **-O3** sieve.c
 $ time ./a.out

--- a/mc.c
+++ b/mc.c
@@ -2005,7 +2005,10 @@ int *codegen(int *jitmem, int *jitmap)
          if (i == LEV || i == JMP) genpool = 1;
          else if ( ((int) je > (int) imm0 + 3072) || // pad for optimizer
                    (immf0 && ((int) je > (int) immf0 + 512)) ) {
-            tje = je++; genpool = 2;
+            tje = je; --tje; // workaround for "*(ptr - literal)" bug
+            if (*tje != 0xe1a01001) { // NOP : mov r1, r1
+               tje = je++; genpool = 2;
+            }
          }
       }
       if (genpool) {
@@ -2422,7 +2425,8 @@ int elf32(int poolsz, int *main, int elf_fd)
    // .interp (embedded in PT_LOAD of data)
    char *interp_str = "/lib/ld-linux-armhf.so.3";
    int interp_str_size = 25; // strlen(interp_str) + 1
-   char *interp = data; memcpy(interp, interp_str, interp_str_size);
+   char *interp = data;
+   memcpy(interp, interp_str, interp_str_size);
    int interp_off = pt_dyn_off + pt_dyn_size; data += interp_str_size;
    o += interp_str_size;
 


### PR DESCRIPTION
Sieve.c benchmark now runs as fast as gcc -O3 compile.

Note: I am blitzing through adding new optimizations and
will clean up this very messy code when I am done.