### PR TITLE
Patch critical multi-assignment declaration bug.

### DIFF
--- a/mc.c
+++ b/mc.c
@@ -1435,6 +1435,7 @@ void stmt(int ctx)
        * "enum" finishes by "tk == ';'", so the code below will be skipped.
        * While current token is not statement end or block end.
        */
+      b = 0;
       while (tk != ';' && tk != '}' && tk != ',' && tk != ')') {
          ty = bt;
          // if the beginning of * is a pointer type, then type plus `PTR`
@@ -1453,6 +1454,7 @@ void stmt(int ctx)
          next();
          id->type = ty;
          if (tk == '(') { // function
+            if (b != 0) fatal("func decl can't be mixed with var decl(s)");
             if (ctx != Glo) fatal("nested function");
             if (ty > FLOAT && ty < PTR) fatal("return type can't be struct");
             if (id->class == Syscall && id->val)
@@ -1528,9 +1530,11 @@ unwind_func: id = sym;
             }
             if (ctx == Loc && tk == Assign) {
                int ptk = tk;
-               *--n = loc - id->val; *--n = Loc;
+               if (b == 0) *--n = ';';
+               b = n; *--n = loc - id->val; *--n = Loc;
                next(); a = n; i = ty; expr(ptk);
                *--n = (int)a; *--n = (ty << 16) | i; *--n = Assign; ty = i;
+               *--n = (int) b; *--n = '{';
             }
          }
          if (ctx != Par && tk == ',') next();


### PR DESCRIPTION
The following declaration was only doing the last assign before this patch.

 int a = 1, b = 2, c = 3;