### PR TITLE
Add Alias operator ":=" for labeling memory locations.

### DIFF
--- a/tests/shock.c
+++ b/tests/shock.c
@@ -108,8 +108,8 @@ void ComputeFaceInfo(int numFace, float *mass, float *momentum, float *energy,
    for (i = 0; i < numFace; ++i)
    {
       /* each face has an upwind and downwind element. */
-      int upWind   = i;     /* upwind element */
-      int downWind = i + 1; /* downwind element */
+      int upWind   := i;     /* upwind element */
+      int downWind := i + 1; /* downwind element */
 
       /* calculate face centered quantities */
       float massf =     0.5 * (mass[upWind]     + mass[downWind]);
@@ -182,8 +182,8 @@ void UpdateElemInfo(int numElem, float *mass, float *momentum,
    for (i = 1; i < numElem; ++i)
    {
       /* each element inside the tube has an upwind and downwind face */
-      int upWind = i-1;     /* upwind face */
-      int downWind = i;   /* downwind face */
+      int upWind := i-1;     /* upwind face */
+      int downWind := i;   /* downwind face */
 
       mass[i]     -= gammaInverse*(f0[downWind] - f0[upWind])*dtdx;
       momentum[i] -= gammaInverse*(f1[downWind] - f1[upWind])*dtdx;

--- a/tests/shock_as.c
+++ b/tests/shock_as.c
@@ -24,6 +24,10 @@
 #include <stdio.h>
 #include <math.h>
 
+#ifndef __MC__
+#define := =
+#endif
+
 float gammaa       = 1.4142135;
 float gammaInverse = 0.70710678;
 
@@ -109,8 +113,8 @@ void ComputeFaceInfo(int numFace, float *mass, float *momentum, float *energy,
    for (i = 0; i < numFace; ++i)
    {
       /* each face has an upwind and downwind element. */
-      int upWind   = i;     /* upwind element */
-      int downWind = i + 1; /* downwind element */
+      int upWind   := i;     /* upwind element */
+      int downWind := i + 1; /* downwind element */
 
       /* calculate face centered quantities */
       float massf =     0.5 * (mass[upWind]     + mass[downWind]);
@@ -183,8 +187,8 @@ void UpdateElemInfo(int numElem, float *mass, float *momentum,
    for (i = 1; i < numElem; ++i) 
    {
       /* each element inside the tube has an upwind and downwind face */
-      int upWind = i-1;     /* upwind face */
-      int downWind = i;   /* downwind face */
+      int upWind := i-1;     /* upwind face */
+      int downWind := i;   /* downwind face */
 
       mass[i]     -= gammaInverse*(fl[downWind].f0 - fl[upWind].f0)*dtdx;
       momentum[i] -= gammaInverse*(fl[downWind].f1 - fl[upWind].f1)*dtdx;

--- a/tests/shock_struct.c
+++ b/tests/shock_struct.c
@@ -108,8 +108,8 @@ void ComputeFaceInfo(int numFace, struct con *cv, struct flux *fl)
    for (i = 0; i < numFace; ++i)
    {
       /* each face has an upwind and downwind element. */
-      int upWind   = i;     /* upwind element */
-      int downWind = i + 1; /* downwind element */
+      int upWind   := i;     /* upwind element */
+      int downWind := i + 1; /* downwind element */
 
       /* calculate face centered quantities */
       float massf =     0.5 * (cv[upWind].mass + cv[downWind].mass);
@@ -181,8 +181,8 @@ void UpdateElemInfo(int numElem, struct con *cv, float *pressure,
    for (i = 1; i < numElem; ++i) 
    {
       /* each element inside the tube has an upwind and downwind face */
-      int upWind = i-1;     /* upwind face */
-      int downWind = i;   /* downwind face */
+      int upWind := i-1;     /* upwind face */
+      int downWind := i;   /* downwind face */
 
       cv[i].mass   -= gammaInverse*(fl[downWind].f0 - fl[upWind].f0)*dtdx;
       cv[i].mom    -= gammaInverse*(fl[downWind].f1 - fl[upWind].f1)*dtdx;


### PR DESCRIPTION
This can be useful in optimizing indexing optimizations for reasons I won't go into.

    int i := B[5][3];  // i is an alias of a specific memory location

The compiler in this repo is a prototype. 

The alias operator would normally not be needed, because a "real" compiler could do the aliasing automatically
if it searches the function context and finds that the variable 'i' declared above is never reassigned after initialization.