### PR TITLE
Intermediate update for enhanced correctness checking.

### DIFF
--- a/tests/bezier.c
+++ b/tests/bezier.c
@@ -12,11 +12,12 @@ int hull_area(int *x, int *y)
     return ((area < 0) ? -area : area) / 2;
 }
 
+int lx = 1 << 31, ly = 1 << 31;
+
 void cubic_bezier(int *px, int *py, int threshold)
 {
     if (hull_area(px, py) < threshold) {
-        int i, lx, ly;
-        for (i = 0; i < 4; ++i) {
+        for (int i = 0; i < 4; ++i) {
             if (lx != px[i] || ly != py[i]) {
                 lx = px[i];
                 ly = py[i];


### PR DESCRIPTION
This update adds two error message enhancements:

"var use before assignment" -- variable is declared, but used before being set.
"modifying uninitialized variable" -- when an inc/dec operator is applied to a declared but not set variable

It also sets internal flags for more advanced error analysis that requires a refactoring of the symbol tables.  That refactoring will follow this update and will include additional warning messages.

Finally, fixed a bug that was preventing initialization of multiple variables in a declaration statement.  Initialization of a single declared variable was already working (see inDecl related changes in source code).
