### PR TITLE
Increase I-cache efficiency. Tweak physics tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ check: $(EXEC) $(TEST_OBJ)
 	$(Q)if [ "$(shell $(ARM_EXEC) ./$(BIN) $(BIN).c tests/hello.c)" = "hello, world" ]; then \
 	$(call pass); \
 	fi
+	@echo
 	@echo "Type 'make show_asm' to create assembly listing in ASM directory"
 
 bench: $(EXEC) $(OBJ_DIR)/$(BIN)-opt

--- a/tests/shock.c
+++ b/tests/shock.c
@@ -263,7 +263,7 @@ int main(void)
    float time = 0.0f;
    float dx = 1.0f / (float) numElems;
    float dt = 0.4f * dx;
-   int currCycle = 0;
+   int currCycle;
 
    for (currCycle=0; currCycle<numTotalCycles; ++currCycle)
    {

--- a/tests/shock_as.c
+++ b/tests/shock_as.c
@@ -263,7 +263,7 @@ int main(void)
    float time = 0.0f;
    float dx = 1.0f / (float) numElems;
    float dt = 0.4f * dx;
-   int currCycle = 0;
+   int currCycle;
 
    for (currCycle=0; currCycle<numTotalCycles; ++currCycle)
    {

--- a/tests/shock_as_p.c
+++ b/tests/shock_as_p.c
@@ -276,7 +276,7 @@ int main(void)
    float time = 0.0f;
    float dx = 1.0f / (float) numElems;
    float dt = 0.4f * dx;
-   int currCycle = 0;
+   int currCycle;
 
    for (currCycle=0; currCycle<numTotalCycles; ++currCycle)
    {

--- a/tests/shock_p.c
+++ b/tests/shock_p.c
@@ -273,7 +273,7 @@ int main(void)
    float time = 0.0f;
    float dx = 1.0f / (float) numElems;
    float dt = 0.4f * dx;
-   int currCycle = 0;
+   int currCycle;
 
    for (currCycle=0; currCycle<numTotalCycles; ++currCycle)
    {

--- a/tests/shock_struct.c
+++ b/tests/shock_struct.c
@@ -247,7 +247,7 @@ int main(void)
    float time = 0.0f;
    float dx = 1.0f / (float) numElems;
    float dt = 0.4f * dx;
-   int currCycle = 0;
+   int currCycle;
 
    for (currCycle=0; currCycle<numTotalCycles; ++currCycle)
    {

--- a/tests/shock_struct_p.c
+++ b/tests/shock_struct_p.c
@@ -275,7 +275,7 @@ int main(void)
    float time = 0.0f;
    float dx = 1.0f / (float) numElems;
    float dt = 0.4f * dx;
-   int currCycle = 0;
+   int currCycle;
 
    for (currCycle=0; currCycle<numTotalCycles; ++currCycle)
    {


### PR DESCRIPTION
There are several known deficiencies in this pull request:

(1) Instruction-stream constants of the form 0xeb------ could be improperly modified.

(2) Using ./mc-so to compile a program will produce smaller executables than using ./squint .

(3) Still need to remove functions that are never called, and thus unreachable during execution.