### PR TITLE
Intermediate update to allow optimizer ro optimize itself.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,11 @@ $(BIN): $(BIN).c
 $(BIN)-so: $(BIN).c $(PEEP).c
 	$(VECHO) "  CC+LD\t\t$@\n"
 	$(Q)if [ "$(shell uname -m)" != "aarch64" ]; then
-	$(Q)$(ARM_CC) -DSQUINT_SO $(CFLAGS) -c -fpic $(PEEP).c
+	$(Q)$(ARM_CC) -DSQUINT_SO=1 $(CFLAGS) -c -fpic $(PEEP).c
 	$(Q)$(ARM_CC) -shared -o lib$(PEEP).so $(PEEP).o
-	$(Q)$(ARM_CC) -DSQUINT_SO -g $(CFLAGS) $(CURR_DIR)/lib$(PEEP).so -o $@ $< -ldl
+	$(Q)$(ARM_CC) -DSQUINT_SO=1 -g $(CFLAGS) $(CURR_DIR)/lib$(PEEP).so -o $@ $< -ldl
 	else
-	$(Q)$(ARM_CC) -DSQUINT_SO -g $(CFLAGS) -o $@ $< -ldl
+	$(Q)$(ARM_CC) -DSQUINT_SO=1 -g $(CFLAGS) -o $@ $< -ldl
 	fi
 
 $(BIN)-native: $(BIN).c


### PR DESCRIPTION
If the following line in squint.c is commented out, then the optimizer can already optimize itself:

lastInstruction = relocate_nop(begin, end - 1, InterFunc);

What this line does is compress the machine instructions in memory as tightly as possible, potentially improving the Icache efficiency.  In practice, this is not necessary, because the Icache is pretty smart.  This capability was added just for the coolness factor.