### PR TITLE
Work through bugs found due to optimizer optimizing itself.

### DIFF
--- a/mc.c
+++ b/mc.c
@@ -364,8 +364,10 @@ char *strrchr(char *s, int c);
 #endif
 
 #ifdef SQUINT_SO
+#ifndef __MC__
 int *squint_opt(int *begin, int *end);
 #include "squint.c"
+#endif
 #endif
 
 char *append_strtab(char **strtab, char *str)


### PR DESCRIPTION
The squint executable now bootstrap optimizes itself through the mc compiler, where it previously used to use gcc.  The mc-so executable is still created by the gcc compiler.  The mc-so executable conatins a gcc compilation of both the mc compiler and the optimizer.